### PR TITLE
Use Zellij v0.37.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [dependencies]
 ansi_term = "0.12.1"
 strum = { version = "0.20", features = ["derive"] }
-zellij-tile = "0.36.0"
-zellij-tile-utils = "0.36.0"
+zellij-tile = "0.37.2"
+zellij-tile-utils = "0.37.2"


### PR DESCRIPTION
Just making the plugin able to work with the most recent Zellij version.

Thanks for developing this!